### PR TITLE
support basic emojis before 0xFFFF & performance optimization

### DIFF
--- a/emoutils.js
+++ b/emoutils.js
@@ -3,18 +3,6 @@
 // 2.肤色对所有emoji都是有效的
 // 3.joiner连接起来的emoji都算一个
 
-const EMOJIS = [
-  // pairs of regional indicators (which display emoji country flags)
-  /\ud83c[\udde6-\uddff]\ud83c[\udde6-\uddff]/,
-  // the unofficial emoji flags for England, Scotland and Wales
-  // each of these begins with the black flag emoji and ends with the cancel tag
-  /\ud83c\udff4(?:\udb40[\udc20-\udc7e])+?\udb40\udc7f/,
-  // range of surrogate pairs
-  /[\ud800-\udbff][\udc00-\udfff]/
-];
-// zero width joiner
-const EMOJI_JOINER = /\u200d/;
-const EMOJI_JOIN_SQUARE = /\u2b1b|\u2b1c/;
 // 后缀控制符
 const EMOJI_INDICATORS = [
   // VARIATION SELECTOR-15 (VS15), used to request a text presentation for an emoji character.
@@ -24,11 +12,43 @@ const EMOJI_INDICATORS = [
   // combining enclosing keycap, which is used after keycap characters
   /\u20e3/
 ];
+const EMOJIS = [
+  // pairs of regional indicators (which display emoji country flags)
+  /\ud83c[\udde6-\uddff]\ud83c[\udde6-\uddff]/,
+  // the unofficial emoji flags for England, Scotland and Wales
+  // each of these begins with the black flag emoji and ends with the cancel tag
+  /\ud83c\udff4(?:\udb40[\udc20-\udc7e])+?\udb40\udc7f/,
+  // range of surrogate pairs
+  /[\ud800-\udbff][\udc00-\udfff]/,
+  // matchForwarding 例如'\u0023\ufe0f\u20e3'
+  new RegExp('.(?:' + EMOJI_INDICATORS.map(re => re.source).join('|') + ')+'),
+  // emojis before 0xFFFF
+  /[\u231A\u231B\u23E9-\u23EC\u23F0\u23F3\u25FD\u25FE\u2614\u2615\u2648-\u2653\u267F\u2693\u26A1\u26AA\u26AB\u26BD\u26BE\u26C4\u26C5\u26CE\u26D4\u26EA\u26F2\u26F3\u26F5\u26FA\u26FD\u2705\u270A\u270B\u2728\u274C\u274E\u2753-\u2755\u2757\u2795-\u2797\u27B0\u27BF\u2B1B\u2B1C\u2B50\u2B55\u00A9\u00AE\u203C\u2049\u2122\u2139\u2194\u2195\u2196\u2197\u2198\u2199\u21A9\u21AA\u2328\u23CF\u23ED-\u23EF\u23F1\u23F2\u23F8-\u23FA\u24C2\u25AA\u25AB\u25B6\u25C0\u25FB\u25FC\u2600-\u2604\u260E\u2611\u2618\u261D\u2620\u2622\u2623\u2626\u262A\u262E\u262F\u2638-\u263a\u2640\u2642\u265F\u2660\u2663\u2665\u2666\u2668\u267B\u267E\u2692\u2694-\u2697\u2699\u269B\u269C\u26A0\u26A7\u26B0\u26B1\u26C8\u26CF\u26D1\u26D3\u26E9\u26F0\u26F1\u26F4\u26F7\u26F8\u26F9\u2702\u2708\u2709\u270C\u270D\u270F\u2712\u2714\u2716\u271D\u2721\u2733\u2734\u2744\u2747\u2763\u2764\u27A1\u2934\u2935\u2B05-\u2b07\u3030\u303D\u3297\u3299\u261D\u26F9\u270A-\u270d]/
+];
+// zero width joiner
+const EMOJI_JOINER = /\u200d/;
 const SKIN_TONE_MODIFIERS = /\ud83c[\udffb-\udfff]/;
 const EMOJI_MODIFIERS = [
   // skin tone modifiers
   SKIN_TONE_MODIFIERS
 ].concat(EMOJI_INDICATORS);
+
+const TEXT_TYPE = 'text';
+const OTHER_TYPE = 'other';
+// joiner regexp
+const RE_JOINER = new RegExp('^' + EMOJI_JOINER.source);
+const EMOJI_TESTER_FROM_START = new RegExp('^(?:' + EMOJIS.map(re => re.source).join('|') + ')');
+const EMOJI_TESTER = new RegExp('(?:' + EMOJIS.map(re => re.source).join('|') + ')');
+const RE_EMOJI_FROM_START = new RegExp(
+  EMOJI_TESTER_FROM_START.source +
+  // match following modifiers if exist
+  '(?:' + EMOJI_MODIFIERS.map(re => '(?:' + re.source + ')').join('|') + ')*'
+);
+const RE_EMOJI = new RegExp(
+  EMOJI_TESTER.source +
+  // match following modifiers if exist
+  '(?:' + EMOJI_MODIFIERS.map(re => '(?:' + re.source + ')').join('|') + ')*'
+);
 
 /**
  * 尝试匹配由零宽空格连接起来的emoji
@@ -36,43 +56,12 @@ const EMOJI_MODIFIERS = [
  */
 function _matchJoined(str) {
   let matched = '';
-  // joiner
-  let reJoiner = new RegExp('^' + EMOJI_JOINER.source);
-  let matchedJoiner = str.match(reJoiner);
+  let matchedJoiner = str.match(RE_JOINER);
   if (matchedJoiner) {
     // 吃掉连接符
     matched += matchedJoiner[0];
     str = str.substr(matchedJoiner[0].length);
-    // join Colored squares \u2b1b \u2b1c
-    const squareJoinMatched = str[0].match(EMOJI_JOIN_SQUARE);
-    if (squareJoinMatched) {
-      matched += squareJoinMatched[0];
-      str = str.substr(squareJoinMatched[0].length);
-      matched += _matchJoined(str);
-    } else {
-      matched += matchOneEmoji(str);
-    }
-  }
-
-  return matched;
-}
-
-/**
- * 向后看一位，如'\u0023\ufe0f\u20e3'
- * @param {String} str
- */
-function _matchForwarding(str) {
-  let matched = '';
-  let reForwarding = new RegExp('^.'
-    + '(?:'
-    + '(?:' + EMOJI_INDICATORS.map(re => '(?:' + re.source + ')').join('|') + ')+'
-    + `|${SKIN_TONE_MODIFIERS.source})`
-  );
-  let matchedForwarding = str.match(reForwarding);
-  if (matchedForwarding) {
-    matched += matchedForwarding[0];
-    str = str.substr(matchedForwarding[0].length);
-    matched += _matchJoined(str, matched);
+    matched += matchOneEmoji(str);
   }
 
   return matched;
@@ -81,30 +70,17 @@ function _matchForwarding(str) {
 /**
  * 尝试匹配开头的emoji，失败返回''
  * @param {String} str
+ * @param {Boolean} fromStrStart 可以指定是否从字符串开头开始匹配
  */
-export function matchOneEmoji(str = '') {
+export function matchOneEmoji(str, fromStrStart = true) {
   let matched = '';
-  let isMatched = false;
-  for (let i = 0; i < EMOJIS.length; i++) {
-    let emojiTester = new RegExp('^' + EMOJIS[i].source);
-    if (emojiTester.test(str)) {
-      isMatched = true;
-      const reEmoji = new RegExp(
-          emojiTester.source +
-          // match following modifiers if exist
-          '(?:' + EMOJI_MODIFIERS.map(re => '(?:' + re.source + ')').join('|') + ')*'
-      );
-      let matchedEmoji = str.match(reEmoji);
-      matched += matchedEmoji[0];
-      str = str.substr(matchedEmoji[0].length);
-      matched += _matchJoined(str);
-      break;
-    }
-  }
-
-  // 向后看1位，应对类似'#️⃣'的场景
-  if (!isMatched && str !== '') {
-    matched += _matchForwarding(str);
+  const emojiTester = fromStrStart ? EMOJI_TESTER_FROM_START : EMOJI_TESTER;
+  if (emojiTester.test(str)) {
+    const reEmoji = fromStrStart ? RE_EMOJI_FROM_START : RE_EMOJI;
+    let matchedEmoji = str.match(reEmoji);
+    matched += matchedEmoji[0];
+    str = str.substr(str.indexOf(matched) + matchedEmoji[0].length);
+    matched += _matchJoined(str);
   }
 
   return matched;
@@ -132,6 +108,37 @@ function padStart(str, targetLength, padString) {
     }
     return padString.slice(0,targetLength) + str;
   }
+}
+
+/**
+ * 将字符串拆分为text和other的列表，将emoji等非”纯文本“的独立出来
+ * @param {String} str
+ */
+function splitToSegment(str = '') {
+  const arr = [];
+  while (str.length > 0) {
+    const matched = matchOneEmoji(str, false);
+    if (matched) {
+      const firstIndex = str.indexOf(matched);
+      firstIndex > 0 && arr.push({
+        text: str.slice(0, firstIndex),
+        type: TEXT_TYPE
+      });
+      arr.push({
+        text: matched,
+        type: OTHER_TYPE
+      });
+      str = str.slice(firstIndex + matched.length);
+    } else {
+      // 已经没有other类型了
+      arr.push({
+        text: str,
+        type: TEXT_TYPE
+      });
+      str = '';
+    }
+  }
+  return arr;
 }
 
 /**
@@ -181,13 +188,13 @@ export function str2unicodeArray(str = '') {
  */
 export function length(str = '') {
   let len = 0;
-  let rest = str;
-
-  while (rest.length > 0) {
-    let matchedEmoji = matchOneEmoji(rest);
-    let consumed = matchedEmoji.length || 1;
-    rest = rest.substr(consumed);
-    len++;
+  const segmentArr = splitToSegment(str);
+  for (let i = 0; i < segmentArr.length; i++) {
+    if (segmentArr[i].type === TEXT_TYPE) {
+      len += segmentArr[i].text.length;
+    } else {
+      len += 1;
+    }
   }
 
   return len;
@@ -200,32 +207,13 @@ export function length(str = '') {
  * @param {Number} len 子串长度
  */
 export function substr(str = '', start = 0, len = Infinity) {
-  if (start < 0 || len === Infinity) {
-    let splitted = toArray(str);
-    let len = splitted.length;
-    if (start < 0) {
-      start = len + start;
-    }
-
-    return splitted.slice(start, start + len).join('');
+  let splitted = toArray(str);
+  if (start < 0) {
+    start = splitted.length + start;
   }
 
-  let index = 0;
-  let substring = '';
-  while (str.length > 0 && len > 0) {
-    let matchedEmoji = matchOneEmoji(str);
-    if (!matchedEmoji) {
-      matchedEmoji = str[0];
-    }
-    if (index >= start) {
-      substring += matchedEmoji;
-      len--;
-    }
-    str = str.substr(matchedEmoji.length);
-    index++;
-  }
+  return splitted.slice(start, start + len).join('');
 
-  return substring;
 }
 
 /**
@@ -234,13 +222,13 @@ export function substr(str = '', start = 0, len = Infinity) {
 export function toArray(str = '') {
   let arr = [];
 
-  while (str.length > 0) {
-    let matched = matchOneEmoji(str);
-    if (!matched) {
-      matched = str[0];
+  const segmentArr = splitToSegment(str);
+  for (let i = 0; i < segmentArr.length; i++) {
+    if (segmentArr[i].type === TEXT_TYPE) {
+      arr = arr.concat(segmentArr[i].text.split(''));
+    } else {
+      arr.push(segmentArr[i].text);
     }
-    arr.push(matched);
-    str = str.substr(matched.length);
   }
 
   return arr;

--- a/test.js
+++ b/test.js
@@ -127,11 +127,11 @@ let cases = [
   {
     emoji: '\u0023\ud83c\udfff',
     unicode: '\u0023\ud83c\udfff',
-    array: ['\u0023\ud83c\udfff'],
-    length: 1,
+    array: ['\u0023', '\ud83c\udfff'],
+    length: 2,
     sub: [{
       params: [0, 1],
-      str: '\u0023\ud83c\udfff'
+      str: '\u0023'
     }, {
       params: [0, 2],
       str: '\u0023\ud83c\udfff'
@@ -217,7 +217,7 @@ let cases = [
       str: 'i🌺💰'
     }, {
       params: [-2, 1],
-      str: '。🌚'
+      str: '。'
     }]
   },
   {


### PR DESCRIPTION
抱歉，我又来了，上一次我改完之后只是人工测试验证了表情面板没问题了，我也以为已经很完善了

后来，我为了验证更加全面且更加自动化，写了个脚本，直接拉 https://unicode.org/Public/emoji/13.1/emoji-test.txt 的所有表情来进行验证，发现还是有一种 case 是漏掉了的，就是 `0xFFFF` 码之前的两字节的 emoji 码。同时发现在处理长字符串时性能低下，做了点性能优化

以下是对修改点的逐个说明：

`emoutils.js`的修改
1、6-14和17-26行，只是挪了下位置
2、23-24行，使用一条正则直接代替原本的 `_matchForwaring` 的功能
3、25-26行，包含了 `0xFFFF` 之前的所有的两字节 emoji 码，原来的逻辑只会匹配代理对也就是 `Supplementary Multilingual Plane` 扩展平面里的表情，所有的 BMP 里的能直接显示为 emoji 表情的全都漏过了，漏掉包括直接显示为表情的例如 \u231A⌚ 也包括直接使用 BMP 里的 emoji 表情进行 ZWJ 拼接的例如 \u2764\u200D\ud83d\udd25❤‍🔥。理论上以后继续扩展表情是不会扩展使用 BMP 里的码了，所以我觉得这个正则应该是不会成为一个每次更新 emoji 版本就要适配的规则
4、36-52行，一系列变量初始化，含正则初始化，由于机制变化 `matchOneEmoji` 里 `new RegExp` 的可以改成使用先声明好的正则变量，这对性能提升不小
5、59行，`reJoiner` 正则使用 36-52 行声明的变量
6、64行及前面被删代码，删掉了 `_matchForwarding` 函数，同时，由于第三点修改新增加的正则可以直接匹配 \u2b1b 和 \u2b1c，所以把之前写的对应的特殊处理给移除了，`_matchJoined` 变回原样
7、73-83行，调整 `matchOneEmoji` 函数，支持不从头开始匹配，我新的机制下 for 循环的方式不能用了，改用正则里面做处理（各匹配正则做或处理），同时移除 `_matchForwarding ` 调用
8、113-143行，提供 `splitToSegment` 函数将字符串拆分为”纯文字“和”非纯文字（如emoji）“，然后分别进行处理，对于绝大多数场景都是无 emoji 或少量 emoji 的，所以尽可能直接用原生 split 函数进行分割文本，使用 length 属性进行长度获取，不管他是什么内容都从头开始一个一个吃下性能不好
9、191-197，使用 `splitToSegment` 函数进行 `length` 计算
10、210-215行，使用 `splitToSegment` 函数进行 `substr` 处理
11、225-230，使用`splitToSegment` 函数进行 `toArray` 处理

`test.js` 的修改
1、test.js 测试文件调整，因为改了 `substr` 函数修复了你之前 `start` 参数为负的情况的 bug，这里测试用例也更新一下。之前的问题出在参数 `len` 变量被局部 `len` 变量覆盖了
2、`\u0023\ud83c\udfff` 在新修改的这里不支持了，改回原状



目前使用该最新版本代码，再使用对应的测试脚本可以验证所有的表情都能正常匹配，`length` 计算和 `toArray` 的字符拆分也都正常

以下是我的全覆盖测试脚本(nodejs)示例：
```js
const emojiUtils = require('emoutils');
const request = require('request');

const reqOpts = {
  url: 'https://unicode.org/Public/emoji/13.1/emoji-test.txt'
};

request(reqOpts, (error, res, body) => {
  const emojiList = [];
  let emojiListStr = '';
  body.replace(/; .+?qualified\s+# (.+?) E/gu, ($0, $1) => {
    emojiList.push($1);
    emojiListStr += `${$1}`;
  });
  console.log(emojiList);

  const emoji2Array = emojiUtils.toArray(emojiListStr);
  console.log(emoji2Array);
});
// 对比emojiList 和 emoji2Array的区别
```

🤝🤝🤝